### PR TITLE
Fix: [vite:css] start value has mixed support, consider using flex-start instead

### DIFF
--- a/src/lib/Row.svelte
+++ b/src/lib/Row.svelte
@@ -89,7 +89,7 @@
 	.st-container {
 		display: flex;
 		align-items: baseline;
-		justify-content: start;
+		justify-content: flex-start;
 		margin-bottom: 2px;
 	}
 


### PR DESCRIPTION
Fix #3 